### PR TITLE
Feature/find table warp perspective

### DIFF
--- a/internal/cv/pipeline.go
+++ b/internal/cv/pipeline.go
@@ -2,6 +2,7 @@ package cv
 
 import (
 	"image"
+	"math"
 
 	"gocv.io/x/gocv"
 )
@@ -12,6 +13,61 @@ func FindTable(img gocv.Mat) gocv.Mat {
 	gocv.Threshold(img, &img, 128.0, 255.0, gocv.ThresholdOtsu)
 	gocv.FastNlMeansDenoisingWithParams(img, &img, 11.0, 31, 9)
 	gocv.Canny(img, &img, 50.0, 150.0)
+
+	hierachy := gocv.NewMat()
+	contours := gocv.FindContoursWithParams(img, &hierachy, gocv.RetrievalExternal, gocv.ChainApproxSimple).ToPoints()
+
+	maxArea := 0.0
+	maxRect := gocv.NewPointVector()
+	for _, contour := range contours {
+		hull := gocv.NewMat()
+
+		// This sorts the hull counter-clockwise
+		gocv.ConvexHull(gocv.NewPointVectorFromPoints(contour), &hull, false, true)
+
+		hullPoints := gocv.NewPointVectorFromMat(hull)
+
+		arcLen := gocv.ArcLength(hullPoints, true)
+		points := gocv.ApproxPolyDP(hullPoints, 0.001*arcLen, true)
+
+		if points.Size() != 4 {
+			continue
+		}
+
+		polyArea := gocv.ContourArea(points)
+		if polyArea < maxArea {
+			continue
+		}
+
+		maxArea = polyArea
+		maxRect = points
+	}
+
+	lt, lb, rb, rt := maxRect.At(0), maxRect.At(1), maxRect.At(2), maxRect.At(3)
+
+	lDiff := lt.Sub(lb)
+	rDiff := rt.Sub(rb)
+	bDiff := rb.Sub(lb)
+	tDiff := rt.Sub(lt)
+
+	leftHeight := math.Sqrt(float64(lDiff.Y*lDiff.Y + lDiff.X*lDiff.X))
+	rightHeight := math.Sqrt(float64(rDiff.Y*rDiff.Y + rDiff.X*rDiff.X))
+	bottomWidth := math.Sqrt(float64(bDiff.Y*bDiff.Y + bDiff.X*bDiff.X))
+	topWidth := math.Sqrt(float64(tDiff.Y*tDiff.Y + tDiff.X*tDiff.X))
+
+	maxHeight := int(max(leftHeight, rightHeight))
+	maxWidth := int(max(bottomWidth, topWidth))
+
+	origRect := maxRect
+	destRect := gocv.NewPointVectorFromPoints([]image.Point{
+		image.Pt(0, 0),
+		image.Pt(maxWidth-1, 0),
+		image.Pt(maxWidth-1, maxHeight-1),
+		image.Pt(0, maxHeight-1),
+	})
+
+	transform := gocv.GetPerspectiveTransform(origRect, destRect)
+	gocv.WarpPerspective(img, &img, transform, image.Pt(maxWidth, maxHeight))
 
 	return img
 }

--- a/internal/cv/pipeline.go
+++ b/internal/cv/pipeline.go
@@ -12,6 +12,9 @@ func FindTable(img gocv.Mat) gocv.Mat {
 	gocv.GaussianBlur(img, &img, image.Point{X: 3, Y: 3}, 2.0, 0.0, gocv.BorderDefault)
 	gocv.Threshold(img, &img, 128.0, 255.0, gocv.ThresholdOtsu)
 	gocv.FastNlMeansDenoisingWithParams(img, &img, 11.0, 31, 9)
+
+	prepared := img.Clone()
+
 	gocv.Canny(img, &img, 50.0, 150.0)
 
 	hierachy := gocv.NewMat()
@@ -67,7 +70,7 @@ func FindTable(img gocv.Mat) gocv.Mat {
 	})
 
 	transform := gocv.GetPerspectiveTransform(origRect, destRect)
-	gocv.WarpPerspective(img, &img, transform, image.Pt(maxWidth, maxHeight))
+	gocv.WarpPerspective(prepared, &img, transform, image.Pt(maxWidth, maxHeight))
 
 	return img
 }

--- a/internal/cv/pipeline.go
+++ b/internal/cv/pipeline.go
@@ -1,1 +1,17 @@
 package cv
+
+import (
+	"image"
+
+	"gocv.io/x/gocv"
+)
+
+func FindTable(img gocv.Mat) gocv.Mat {
+	gocv.CvtColor(img, &img, gocv.ColorBGRToGray)
+	gocv.GaussianBlur(img, &img, image.Point{X: 3, Y: 3}, 2.0, 0.0, gocv.BorderDefault)
+	gocv.Threshold(img, &img, 128.0, 255.0, gocv.ThresholdOtsu)
+	gocv.FastNlMeansDenoisingWithParams(img, &img, 11.0, 31, 9)
+	gocv.Canny(img, &img, 50.0, 150.0)
+
+	return img
+}


### PR DESCRIPTION
The internal CV module contains now the function FindTable which returns grayscale version of the original image, which only shows the signature table from an orthogonal perspective.

The function has the signature
```
func FindTable(img gocv.Mat) gocv.Mat
```