### PR TITLE
Building on macos with tesseract and leptonica

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,25 @@
 BINARY_PATH=build/yaac
 SOURCE_PATH=cmd/yaac
 
+# The commented out line below should work on systems that use GNU sed
+# CGO_CPPFLAGS=$(foreach dir,$(shell pkg-config --cflags lept tesseract), $(shell echo "$(dir)" | sed -E 's|(([a-zA-Z]+)\/[0-9.]+\/include\/)\2\/*|\1|g'))
+CGO_LDFLAGS=$(shell pkg-config --libs lept tesseract)
+# The line below is a hacked solution, it works for now,
+# but should be removed in the future for a sed solution as above, that is portable
+CGO_CPPFLAGS=$(foreach dir,$(shell pkg-config --cflags lept tesseract), $(patsubst %include/leptonica, %include, $(dir)))
+
 .PHONY: all build test run clean
 
 yaac: $(SOURCE_PATH)/*.go
-	go build -o ./$(BINARY_PATH) ./$(SOURCE_PATH)
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go build -o ./$(BINARY_PATH) ./$(SOURCE_PATH)
 
 all: build test
 
 build:
-	go build -o ./$(BINARY_PATH) ./$(SOURCE_PATH)
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go build -o ./$(BINARY_PATH) ./$(SOURCE_PATH)
 
 test:
-	go test -v ./test/
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go test -v ./test/
 
 run: build
 	./$(BINARY_PATH)


### PR DESCRIPTION
When bringing tesseract and leptonica into the rest of the project, some difficulties arose around the Go bindings for tesseract, because they hardcoded the leptonica linker flag to `-llept`, but on some systems (like Arch Linux or MacOS it is `-lleptonica`.
In this pull request a general solution using `pkg-config` is provided.
It currently contains a hacked solution for detecting `...leptonica/<version>/include/leptonica` and removing the last `leptonica` because elsewise the required headers are not correctly found.