### PR TITLE
renamed EmailData to MailLoginData

### DIFF
--- a/internal/frontend/mail/window.go
+++ b/internal/frontend/mail/window.go
@@ -62,7 +62,7 @@ func makeFormTab(_ fyne.Window, f *WindowMail) fyne.CanvasObject {
 		},
 		OnSubmit: func() {
 
-			formStruct := yaac_shared.EmailData{
+			formStruct := yaac_shared.MailLoginData{
 				MailServer: mailServer.Text,
 				Email:      email.Text,
 				Password:   password.Text,

--- a/internal/frontend/opencv/mvvm.go
+++ b/internal/frontend/opencv/mvvm.go
@@ -5,7 +5,7 @@ import (
 )
 
 type mvvm interface {
-	MailFormUpdated(data yaac_shared.EmailData)
+	MailFormUpdated(data yaac_shared.MailLoginData)
 	StartGoCV(img_path string)
 }
 

--- a/internal/mvvm/mail.go
+++ b/internal/mvvm/mail.go
@@ -7,7 +7,7 @@ import (
 
 var mailBackend *yaac_backend_mail.BackendMail = nil
 
-func (m *MVVM) NewMailBacked(loginCredentials yaac_shared.EmailData) error {
+func (m *MVVM) NewMailBacked(loginCredentials yaac_shared.MailLoginData) error {
 	b, err := yaac_backend_mail.New(m, loginCredentials.MailServer, loginCredentials.Email, loginCredentials.Password)
 	if err != nil {
 		return err
@@ -22,7 +22,7 @@ func (m *MVVM) GetMailsToday() ([]yaac_backend_mail.MailData, error) {
 	return mailBackend.GetMailsToday()
 }
 
-func (m *MVVM) UpdateMailCredentials(credentials yaac_shared.EmailData) error {
+func (m *MVVM) UpdateMailCredentials(credentials yaac_shared.MailLoginData) error {
 	return m.NewMailBacked(credentials)
 }
 

--- a/internal/mvvm/main.go
+++ b/internal/mvvm/main.go
@@ -34,7 +34,7 @@ func (m *MVVM) StartApplication() {
 	// ms["UserEmail"] = "myemail@email.server"
 	// ms["UserEmailPassword"] = "123"
 
-	// err = m.NewMailBacked(yaac_shared.EmailData{MailServer: ms["MailServer"], Email: ms["UserEmail"], Password: ms["UserEmailPassword"]})
+	// err = m.NewMailBacked(yaac_shared.MailLoginData{MailServer: ms["MailServer"], Email: ms["UserEmail"], Password: ms["UserEmailPassword"]})
 	// if err != nil {
 	// 	log.Fatalf("Could not connect to email server")
 	// }

--- a/internal/shared/mvvm.go
+++ b/internal/shared/mvvm.go
@@ -10,7 +10,7 @@ type MVVM interface {
 	NotifyNewList(list AttendanceList)
 
 	// Mail
-	UpdateMailCredentials(credentials EmailData) error
+	UpdateMailCredentials(credentials MailLoginData) error
 	GetMailsToday() ([]MailData, error)
 	CheckMailConnection() bool
 

--- a/internal/shared/shared.go
+++ b/internal/shared/shared.go
@@ -23,7 +23,7 @@ func GetApp() *fyne.App {
 	return &App
 }
 
-type EmailData struct {
+type MailLoginData struct {
 	MailServer string
 	Email      string
 	Password   string


### PR DESCRIPTION
Until now was "Emaildata" the login data (the user credentials) and "MailData" the binary image and the date and time from the mail.
To avoid errors and confusion, I would rename EmailData to MailLoginData to make a clear distinction between these two.