### PR TITLE
Removed calls to log.Fatal

### DIFF
--- a/internal/backend/demon/demon.go
+++ b/internal/backend/demon/demon.go
@@ -13,20 +13,20 @@ func StartDemon(mvvm shared.MVVM, duration time.Duration) {
 	for {
 		newMails, err := mvvm.GetMailsToday()
 		if err != nil {
-			log.Fatalf("Could not get mails for today: %v", err)
+			log.Println("ERROR: Could not get mails for today: ", err)
 			continue
 		}
 
 		for _, mail := range newMails {
 			list, err := TableToAttendanceList(mvvm, mail)
 			if err != nil {
-				log.Fatalf("Could not process image from mail received at %v", mail.ReceivedAt)
+				log.Println("ERROR: Could not process image from mail received at ", mail.ReceivedAt)
 				continue
 			}
 
 			_, err = mvvm.InsertList(list)
 			if err != nil {
-				log.Fatalf("Could not add list for mail received at %v: %v", mail.ReceivedAt, err)
+				log.Printf("ERROR: Could not add list for mail received at %v: %v\n", mail.ReceivedAt, err)
 				continue
 			}
 

--- a/internal/frontend/mail/window.go
+++ b/internal/frontend/mail/window.go
@@ -69,7 +69,7 @@ func makeFormTab(_ fyne.Window, f *WindowMail) fyne.CanvasObject {
 			// FIXME: Error handling here
 			err := f.MVVM.UpdateMailCredentials(formStruct)
 			if err != nil {
-				log.Fatalf("Could not update E-Mail credentials")
+				log.Println("ERROR: Could not update E-Mail credentials")
 			}
 		},
 	}

--- a/internal/mvvm/imgproc.go
+++ b/internal/mvvm/imgproc.go
@@ -4,22 +4,7 @@ import (
 	imgproc "github.com/DHBW-SE-2023/YAAC/internal/backend/imgproc"
 )
 
-<<<<<<< Updated upstream
 func (m *MVVM) ImgprocBackendStart() {
 	m.BackendImgproc = imgproc.NewBackend(m)
 	m.NewTable([]byte{})
-=======
-func (m *MVVM) ValidateTable(img []byte) {
-	b := imgproc.NewBackend(m)
-	f := frontend.New(m)
-
-	go func() {
-		table, err := b.ValidateTable(img)
-		if err != nil {
-			log.Println("backend.ValidateTable: ", err)
-		}
-
-		f.ReceiveNewTable(table)
-	}()
->>>>>>> Stashed changes
 }

--- a/internal/mvvm/imgproc.go
+++ b/internal/mvvm/imgproc.go
@@ -4,7 +4,22 @@ import (
 	imgproc "github.com/DHBW-SE-2023/YAAC/internal/backend/imgproc"
 )
 
+<<<<<<< Updated upstream
 func (m *MVVM) ImgprocBackendStart() {
 	m.BackendImgproc = imgproc.NewBackend(m)
 	m.NewTable([]byte{})
+=======
+func (m *MVVM) ValidateTable(img []byte) {
+	b := imgproc.NewBackend(m)
+	f := frontend.New(m)
+
+	go func() {
+		table, err := b.ValidateTable(img)
+		if err != nil {
+			log.Println("backend.ValidateTable: ", err)
+		}
+
+		f.ReceiveNewTable(table)
+	}()
+>>>>>>> Stashed changes
 }


### PR DESCRIPTION
Calls to `log.Fatal` or similar functions in main code (testing code excluded) were removed, with the exception of `internal/frontend/main/mvvm.go` were an implementation is yet missing so it is appropriate to crash there.